### PR TITLE
Cache-bust assets on deploy so updates load fresh

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # Stamp the commit SHA onto cached asset URLs so browsers/CDN always
+      # fetch fresh JS, CSS, and sprite atlas after a deploy (source files stay
+      # clean; only the published copy is rewritten).
+      - name: Cache-bust asset references
+        run: |
+          VER="${GITHUB_SHA::8}"
+          sed -i "s#src=\"main.js\"#src=\"main.js?v=$VER\"#" index.html
+          sed -i "s#href=\"style.css\"#href=\"style.css?v=$VER\"#" index.html
+          sed -i "s#assets/sprites.png#assets/sprites.png?v=$VER#g" main.js
+          sed -i "s#assets/sprites.json#assets/sprites.json?v=$VER#g" main.js
+
       # Static site, no build step — publish the repo root as-is
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
## Why
Caching has now caused two visible problems this session — Sawyer-man appearing too small (the new `main.js` wasn't loading) and a garbled idle face (a half-updated atlas after the recent rebuilds). The site loads `main.js`, `style.css`, and the sprite atlas by plain filename with no version, so browsers/CDN keep serving stale copies after a deploy.

## What
Adds one step to the Pages deploy that stamps the commit SHA onto the published asset URLs before publishing:
- `index.html`: `main.js?v=<sha>`, `style.css?v=<sha>`
- `main.js`: `assets/sprites.png?v=<sha>` (fetch, `loadImage`, and the inline `url(...)` block backgrounds) and `assets/sprites.json?v=<sha>`

Browsers and any CDN treat the new query as a new resource, so JS/CSS/atlas changes load immediately after a deploy. Source files stay clean — only the published copy in the runner is rewritten, so there's no manual version bump to forget.

Verified the `sed` rewrites locally: all five references get versioned and the rewritten `main.js` still parses.

## Note
This takes effect on the next deploy. For the current stale view, a hard refresh is still needed once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcBjMZ4zDBaQcHVevahbHf)_