### PR TITLE
Draw the cyclist in front so she doesn't merge with Sawyer-man

### DIFF
--- a/main.js
+++ b/main.js
@@ -425,14 +425,6 @@
         drawSprite('ground', 0, gx, gy, S, false);
       }
 
-      // cyclist rides along the ground line, behind Sawyer-man and the cats.
-      // Atlas art faces right; flip so she heads left. Wheels meet the ground.
-      if (nikki.active) {
-        var nkr = rectOf('nikki-bike', 0);
-        drawSprite('nikki-bike', animFrame('nikki-bike', 0),
-          nikki.x, gy - nkr.h * S + 4 * S, S, true);
-      }
-
       cats.forEach(function (cat) {
         var r = rectOf(cat.name, 0);
         drawSprite(cat.name, animFrame(cat.name, cat.phase),
@@ -449,6 +441,16 @@
       var sy = gy + 2 * S - sr.h * scale + sawyer.jumpY * S;
       // all sprites face right in the atlas; flip when heading left
       drawSprite(animName, animFrame(animName, 0), sx, sy, scale, sawyer.dir < 0);
+
+      // cyclist rides along the ground line in the FOREGROUND, in front of
+      // Sawyer-man and the cats, so when she crosses paths she cleanly passes
+      // in front of them instead of her taller head poking up behind his.
+      // Atlas art faces right; flip so she heads left. Wheels meet the ground.
+      if (nikki.active) {
+        var nkr = rectOf('nikki-bike', 0);
+        drawSprite('nikki-bike', animFrame('nikki-bike', 0),
+          nikki.x, gy - nkr.h * S + 4 * S, S, true);
+      }
     }
 
     var last = 0;


### PR DESCRIPTION
## What you were seeing
The "glitching between two sprites" / "can't see his face" was **Nikki overlapping Sawyer-man**, not a cache issue (the cache-bust did fix the separate stale-render problem — walk/idle/jump now render cleanly on their own). Nikki was drawn *behind* the ground characters, and since she's slightly taller than Sawyer-man, when they crossed paths her **helmet and braid poked up around his head**, making him look like a glitchy helmet-wearing mutant.

Reproduced and compared both depth orders at real scale:
- **Behind (old):** her helmet lands on his head, braid crosses his face → looks broken.
- **Front (new):** she cleanly passes in front of him, he's visible behind → reads as a cyclist riding by.

## Change
Move Nikki's draw to the **foreground** (after Sawyer-man and the cats) so overlaps read as a natural front-pass. Still purely ambient — no collision, no interaction; she just rides through. One render-order change in `main.js`.

## Preview
`python3 -m http.server 8000` → `http://localhost:8000`. When the cyclist crosses Sawyer-man now, she passes in front instead of merging with his head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcBjMZ4zDBaQcHVevahbHf)_